### PR TITLE
コード簡素化

### DIFF
--- a/app/coopReminder.js
+++ b/app/coopReminder.js
@@ -1,16 +1,9 @@
-const axiosBase = require('axios');
+const axios = require('axios').default;
 const AWS = require('aws-sdk');
 
 const ssm = new AWS.SSM();
 
 module.exports.handler = async (event) => {
-  const axios = axiosBase.create({
-    baseURL: '',
-    headers: {
-      'Content-Type': 'application/json; charset=UTF-8',
-    },
-  });
-
   const botUri = await ssm
     .getParameter({
       Name: '/CoopReminder/BOT_URI',
@@ -19,11 +12,8 @@ module.exports.handler = async (event) => {
     .promise()
     .then((ret) => ret.Parameter.Value);
 
-  const res = await axios.post(botUri, {
+  await axios.post(botUri, {
     chat_id: event.chat_id,
     text: event.text,
   });
-  if (res.status !== 200) {
-    throw new Error(`${res.status} ${res.statusText}`);
-  }
 };


### PR DESCRIPTION
- [x] axios はデフォルトで `Content-Type: application/json` を付けるので、コードで書かない
- [x] `require('axios').default` と書くことで intellisense が効くようにする
- [x] axios は 200 応答以外では rejected になるので、エラー処理を見直す