### PR TITLE
毎日20時起動とし、ChangeCalendarがopenの時だけtelegram通知するように修正

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -4,12 +4,18 @@ const mockSSMGetParameter = jest.fn(() => ({
   promise: mockAwsPromise,
 }));
 
+const mockSSMGetCalendarState = jest.fn(() => ({
+  promise: mockAwsPromise,
+}));
+
 const SSM = jest.fn(() => ({
   getParameter: mockSSMGetParameter,
+  getCalendarState: mockSSMGetCalendarState,
 }));
 
 module.exports = {
   mockAwsPromise,
   mockSSMGetParameter,
+  mockSSMGetCalendarState,
   SSM,
 };

--- a/__tests__/coopReminder.test.js
+++ b/__tests__/coopReminder.test.js
@@ -1,17 +1,33 @@
 const axios = require('axios');
 const { handler } = require('../app/coopReminder');
-const { mockAwsPromise, mockSSMGetParameter } = require('../__mocks__/aws-sdk');
+const {
+  mockAwsPromise,
+  mockSSMGetParameter,
+  mockSSMGetCalendarState,
+} = require('../__mocks__/aws-sdk');
 
 jest.mock('axios');
 
 describe('coopReminder', () => {
+  beforeEach(() => {
+    process.env.CALENDAR_NAME = 'cc';
+  });
+
+  afterEach(() => {
+    delete process.env.CALENDAR_NAME;
+  });
+
   test('normal', async () => {
     axios.default.post.mockResolvedValueOnce();
-    mockAwsPromise.mockResolvedValueOnce({
-      Parameter: {
-        Value: 'https://api.telegram.org/hogehoge/sendMessage',
-      },
-    });
+    mockAwsPromise
+      .mockResolvedValueOnce({
+        State: 'OPEN',
+      })
+      .mockResolvedValueOnce({
+        Parameter: {
+          Value: 'https://api.telegram.org/hogehoge/sendMessage',
+        },
+      });
 
     await handler({
       chat_id: -3135,
@@ -26,6 +42,10 @@ describe('coopReminder', () => {
         text: 'こんにちは',
       }
     );
+    expect(mockSSMGetCalendarState).toHaveBeenCalledTimes(1);
+    expect(mockSSMGetCalendarState).toHaveBeenCalledWith({
+      CalendarNames: [process.env.CALENDAR_NAME],
+    });
     expect(mockSSMGetParameter).toHaveBeenCalledTimes(1);
     expect(mockSSMGetParameter).toHaveBeenCalledWith({
       Name: '/CoopReminder/BOT_URI',
@@ -39,11 +59,15 @@ describe('coopReminder', () => {
         status: 500,
       },
     });
-    mockAwsPromise.mockResolvedValueOnce({
-      Parameter: {
-        Value: 'https://api.telegram.org/hogehoge/sendMessage',
-      },
-    });
+    mockAwsPromise
+      .mockResolvedValueOnce({
+        State: 'OPEN',
+      })
+      .mockResolvedValueOnce({
+        Parameter: {
+          Value: 'https://api.telegram.org/hogehoge/sendMessage',
+        },
+      });
 
     try {
       await handler({
@@ -62,10 +86,32 @@ describe('coopReminder', () => {
         text: 'さようなら',
       }
     );
+    expect(mockSSMGetCalendarState).toHaveBeenCalledTimes(1);
+    expect(mockSSMGetCalendarState).toHaveBeenCalledWith({
+      CalendarNames: [process.env.CALENDAR_NAME],
+    });
     expect(mockSSMGetParameter).toHaveBeenCalledTimes(1);
     expect(mockSSMGetParameter).toHaveBeenCalledWith({
       Name: '/CoopReminder/BOT_URI',
       WithDecryption: true,
     });
+  });
+
+  test('skip by calendar', async () => {
+    mockAwsPromise.mockResolvedValueOnce({
+      State: 'CLOSED',
+    });
+
+    await handler({
+      chat_id: -4135,
+      text: 'もしもし',
+    });
+
+    expect(axios.default.post).not.toHaveBeenCalled();
+    expect(mockSSMGetCalendarState).toHaveBeenCalledTimes(1);
+    expect(mockSSMGetCalendarState).toHaveBeenCalledWith({
+      CalendarNames: [process.env.CALENDAR_NAME],
+    });
+    expect(mockSSMGetParameter).not.toHaveBeenCalled();
   });
 });

--- a/app/coopReminder.js
+++ b/app/coopReminder.js
@@ -7,6 +7,18 @@ const axios = require('axios').default;
 const ssm = new AWS.SSM();
 
 module.exports.handler = async (event) => {
+  // ChanageCalendarがopenでないときはスキップする
+  const state = await ssm
+    .getCalendarState({
+      CalendarNames: [process.env.CALENDAR_NAME],
+    })
+    .promise()
+    .then((ret) => ret.State);
+  if (state !== 'OPEN') {
+    console.log('Calendar is not open, then skipped.');
+    return;
+  }
+
   const botUri = await ssm
     .getParameter({
       Name: '/CoopReminder/BOT_URI',

--- a/awssdklayer/nodejs/package.json
+++ b/awssdklayer/nodejs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "awssdklayer",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "aws-sdk": "^2.596.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": ""
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,6 +22,11 @@ provider:
       Action:
         - "ssm:GetParameter"
       Resource: "arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter/*"
+    - Effect: Allow
+      Action:
+        - ssm:GetCalendarState
+      Resource:
+        - arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:document/*
   deploymentBucket:
     blockPublicAccess: true
   tracing:
@@ -48,9 +53,13 @@ functions:
     events:
       - schedule:
           name: weekly-event
-          description: '毎週定期的に起動するイベント'
-          rate: cron(0 11 ? * TUE *)
+          description: '毎日20時に起動するイベント'
+          rate: cron(0 11 * * ? *)
           enabled: true
           input:
             chat_id: -25511902
             text: '締切時刻が近づいています。\n注文はお早めに。'
+    layers:
+      - arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:layer:awssdklayer:6
+    environment:
+      CALENDAR_NAME: myCalendar


### PR DESCRIPTION
- 毎日20時起動とし、ChangeCalendarがopenの時だけtelegram通知するように修正
- SSM の `GetCalendarState` API を呼べるように、最新の AWS-SDK を含むパッケージを layer `awssdklayer` として別に登録

※当初は layer も serverless.yml の中に定義して lambda と同時にデプロイすることを考えたが、

- layer と lambda をひとつの stack で同時に create しようとするため、lambda のデプロイのところで `does not exist` と言われてエラーになる
- lambda のほうに layer の logical ID を dependsOn として指定しても同じくエラー
- layer に `retain: true` を指定すると logical ID によけいなランダム文字列が付加されて dependsOn の指定ができなくなる
- そもそも layer を参照するには「バージョン込みで」layer の ARN を指定しなければならない
  - `serverless-latest-layer-version` などのバージョンを自動解決するプラグインもあるものの、これも先に layer がデプロイ済みになっていないと失敗するわけで…

と、「先に layer が存在していないと二進も三進もいかない」状況になったため、やむを得ず layer は CLI で先に登録して、serverless.yml では登録済み layer の ARN を参照するのみにとどめた。serverless のせいというより、layer の仕様に問題がある(らしい)。

`aws lambda publish-lambda-layer --layer-name awssdklayer --zip-file fileb://awssdklayer.zip`