### PR TITLE
LambdaInsights を組み込む

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,13 +2,14 @@ service: tgbot
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs12.x
   stage: dev
   region: ${env:AWS_REGION, 'ap-northeast-1'}
   memorySize: 512
   timeout: 60
   iamManagedPolicies:
     - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    - arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy
   iamRoleStatements:
     - Effect: "Allow"
       Action:
@@ -51,3 +52,5 @@ functions:
             text: '締切時刻が近づいています。\n注文はお早めに。'
     environment:
       CALENDAR_NAME: myCalendar
+    layers:
+      - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:14"


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights.html を見る限り nodejs14.x には未対応のようなので、いったん nodejs12.x に戻す。